### PR TITLE
fix: better way to get user info from Slack

### DIFF
--- a/src/slack.js
+++ b/src/slack.js
@@ -7,7 +7,7 @@ const {
 const logger = require('./connectors/logger');
 
 const getApiEndpoints = () => ({
-  userDetails: `https://slack.com/api/users.info`,
+  userDetails: `https://slack.com/api/users.identity`,
   oauthToken: `https://slack.com/api/oauth.access`,
   oauthAuthorize: `https://slack.com/oauth/authorize`
 });
@@ -32,14 +32,14 @@ const check = response => {
   );
 };
 
-const slackGet = (url, accessToken) =>
+const slackGet = (url, accessToken, params) =>
   axios({
     method: 'get',
     url,
-    params: {
-      token: accessToken,
-      user: 'U2T7NS9AA'
-    }
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+    },
+    params,
   });
 
 module.exports = (apiBaseUrl, loginBaseUrl) => {


### PR DESCRIPTION
Thanks for sharing this! It was very helpful.

I did have to make a couple of changes to make it work though, and added a couple of improvements.

The user.info endpoint was not working, because Slack requires you to send a userId, and you were sending a fixed harcoded user id that didn't exist (at least at the logged in workspace). But instead of passing the correct userId, I found out that it's better to use the user.identity endpoint, because it requires less permissions. Rather than asking to read info from all users in your workspace (users:read permission) you just need identity:* permissions and you get almost the same, but Slack only asks you about *your data*, which is a lot less invasive and less scary.

Also, I noticed that Slack includes the same identity data in the token response itself when you ask for these scopes, so I shortcut the user info data from the same token response instead of making an additional request from the token endpoint.

I know this is not ready to be merged (it lacks tests for example), but I posted it in case it's helpful for you or someone else. If you feel this should be included, I can improve it.